### PR TITLE
Add better Error handing for redux form

### DIFF
--- a/src/app/ticker/components/TickerForm.js
+++ b/src/app/ticker/components/TickerForm.js
@@ -78,7 +78,14 @@ export default reduxForm({
       // eslint-disable-next-line
       throw { ticker: syncError }
     }
-    if (await TickerRegistry.getDetails(v) !== null) {
+    let details = null
+    try {
+      details = await TickerRegistry.getDetails(v)
+    } catch (err) {
+      console.error('Error fetching details', err)
+    }
+
+    if (details !== null) {
       // eslint-disable-next-line
       throw { ticker: 'Specified ticker is already exists.' }
     }


### PR DESCRIPTION
I was getting an error from redux forms that stated : 'Asynchronous validation promise was rejected without errors.'

This is not very descriptive, as the problem was that I actually forgot to launch the contracts on ganache. 

Adding the lines as seen in the commit allows you to catch the error from TickerRegistry.getDetails(v) if one exists.