### PR TITLE
Fix splashpage typo

### DIFF
--- a/src/app/SplashPage.js
+++ b/src/app/SplashPage.js
@@ -22,7 +22,7 @@ export default class SplashPage extends Component {
             <p>
               <Link to='/ticker'>
                 <Button icon='arrow--right'>
-                  ISSUE YOUR SECURITY TOKEN
+                  CREATE YOUR SECURITY TOKEN
                 </Button>
               </Link>
             </p>


### PR DESCRIPTION
Replace "issue security token" with "create security token"