### PR TITLE
Improve first install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ We only use Yarn as our official Node package manager, so we will only commit ya
 
 To start development run:
 ```
-npm start
+yarn start
 ```
 
 To build application run:
 ```
-npm run build
+yarn build
 ```
 
 By default application works with Kovan testnet.
@@ -32,19 +32,19 @@ Start the ganache cli
 
 **Important: The `contracts` command will fail if `ganache-cli` is not running**
 ```
-npm run ganache-cli
+yarn ganache-cli
 ```
 
 In a separate terminal:
 ```
-npm run contracts
+yarn contracts
 ```
 
 Turn off MetaMask or any other Web3 provider and start/build application.
 
 To open Truffle Console and play with contracts directly:
 ```
-npm run tconsole
+yarn tconsole
 ```
 
 [Read more about Truffle Console](http://truffleframework.com/docs/getting_started/console)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ By default application works with Kovan testnet.
 
 ## Working with contracts locally
 
+Start the ganache cli
+
+**Important: The `contracts` command will fail if `ganache-cli` is not running**
 ```
 npm run ganache-cli
 ```

--- a/package.json
+++ b/package.json
@@ -61,10 +61,11 @@
     "typecheck": "flow",
     "test": "react-scripts test --useStderr --forceExit --runInBand",
     "precommit": "lint-staged && npm run typecheck",
+    "postinstall": "cd node_modules/polymath-core && yarn",
     "build": "npm run build-css && react-scripts build && cp build/index.html build/404.html",
     "ganache-cli": "node_modules/polymath-core/node_modules/.bin/ganache-cli --gasLimit 90000000",
-    "contracts": "cd node_modules/polymath-core && yarn && node ../truffle/build/cli.bundled.js migrate --reset --all --network development",
-    "tconsole": "cd node_modules/polymath-core && yarn && node ../truffle/build/cli.bundled.js console"
+    "contracts": "cd node_modules/polymath-core && node ../truffle/build/cli.bundled.js migrate --reset --all --network development",
+    "tconsole": "cd node_modules/polymath-core && node ../truffle/build/cli.bundled.js console"
   },
   "lint-staged": {
     "src/**/*.js": [

--- a/package.json
+++ b/package.json
@@ -60,12 +60,12 @@
     "lint": "eslint --fix src",
     "typecheck": "flow",
     "test": "react-scripts test --useStderr --forceExit --runInBand",
-    "precommit": "lint-staged && npm run typecheck",
-    "postinstall": "cd node_modules/polymath-core && yarn",
     "build": "npm run build-css && react-scripts build && cp build/index.html build/404.html",
     "ganache-cli": "node_modules/polymath-core/node_modules/.bin/ganache-cli --gasLimit 90000000",
     "contracts": "cd node_modules/polymath-core && node ../truffle/build/cli.bundled.js migrate --reset --all --network development",
-    "tconsole": "cd node_modules/polymath-core && node ../truffle/build/cli.bundled.js console"
+    "tconsole": "cd node_modules/polymath-core && node ../truffle/build/cli.bundled.js console",
+    "precommit": "lint-staged && npm run typecheck",
+    "postinstall": "cd node_modules/polymath-core && yarn"
   },
   "lint-staged": {
     "src/**/*.js": [


### PR DESCRIPTION
This PR makes some small changes to make setting up the repo easier:

- Adds `postinstall` npm hook to auto-install `node_modules/polymath-core` dependencies and ensure we avoid invalid states
- Updates the `Readme.md` file to use `yarn` for running commands instead of `npm`. Since we are enforcing the use of Yarn as the official package manager I thought this would make sense for the sake of consistency.
